### PR TITLE
Use build tags to determine OS and set PATH_SEPERATOR constant

### DIFF
--- a/quotes/path_unix.go
+++ b/quotes/path_unix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package quotes
+
+const PATH_SEPERATOR string = "/"

--- a/quotes/path_windows.go
+++ b/quotes/path_windows.go
@@ -1,0 +1,5 @@
+// +build windows
+
+package quotes
+
+const PATH_SEPERATOR string = "\\"

--- a/quotes/quotes.go
+++ b/quotes/quotes.go
@@ -3,11 +3,11 @@ package quotes
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -27,26 +27,8 @@ type QuoteSlice []QuoteType
 // Parse fetches quotes.json and puts it on a QuoteSlice type.
 func Parse() QuoteSlice {
 
-	// Extremely tedious way to always find the json file.
-	// Its pretty horrible to look at, but it works, somebody please do it better than me.
-	currentDir, _ := os.Getwd()
-	totalDoubleDots := len(strings.Split(currentDir, "/"))
-	var path = ""
-	if os.Getenv("DOCKER") != "" {
-		path = "./quotes/quotes.json"
-		
-	} else {
-		path = os.Getenv("GOPATH") + "/src/github.com/bruno-chavez/ancestorquotes/quotes/quotes.json"
-		goingBack := ""
-		for i := 1; i <= totalDoubleDots; i++ {
-			if i == totalDoubleDots {
-				goingBack = goingBack + ".."
-			} else {
-				goingBack = "../" + goingBack
-			}
-		}
-		path = goingBack + path
-	}
+	// Use PATH_SEPERATOR constant set via build tags
+	path := fmt.Sprintf(".%squotes%squotes.json", PATH_SEPERATOR, PATH_SEPERATOR)
 
 	rawJSON, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
This cleans up the pathing to the JSON file and makes it work in windows too. 