### PR TITLE
Fix all command which wasn't displaying in cli

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -11,8 +11,10 @@ import (
 )
 
 // AllQuotes prints all quotes.
-func AllQuotes() []string {
-	return quotes
+func AllQuotes() {
+	for _, element := range quotes {
+		fmt.Println(element)
+	}
 }
 
 // RandomQuote returns a random quote from the collections of quotes


### PR DESCRIPTION
This change fixes the all command on Mac and should still work for all platforms.