### PR TITLE
add duration option to persistent

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 )
 
 // AllQuotes prints all quotes.
@@ -23,27 +23,16 @@ func RandomQuote() string {
 	return quotes.randomQuote()
 }
 
-// Persistent prints a Quotes every certain amount of time.
-func Persistent(timer int, measure string) {
+// Persistent prints a Quotes every duration of time.
+func Persistent(duration time.Duration) {
 
 	// Running a goroutine makes it possible to print a Quotes and wait for a stop message at the same time.
-	switch measure {
-	case "minute":
-		go func() {
-			ticking := time.Tick(time.Duration(timer) * time.Minute)
-			for range ticking {
-				fmt.Println(quotes.randomQuote())
-			}
-		}()
-
-	case "second":
-		go func() {
-			ticking := time.Tick(time.Duration(timer) * time.Second)
-			for range ticking {
-				fmt.Println(quotes.randomQuote())
-			}
-		}()
-	}
+	go func() {
+		ticking := time.Tick(duration)
+		for range ticking {
+			fmt.Println(quotes.randomQuote())
+		}
+	}()
 
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {

--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"ancestorquotes/commands"
+
 	"github.com/urfave/cli"
 )
 
@@ -16,13 +18,38 @@ func main() {
 	app.Name = "ancestorquotes"
 	app.Author = "bruno-chavez"
 	app.Usage = "Brings quotes from the darkest of dungeons!"
-	app.Version = "2.0.0"
+	app.Version = "2.1.0"
 	app.Commands = []cli.Command{
 		{
 			Name:    "persistent",
 			Usage:   "Makes the Ancestor say a quote every certain amount of time",
 			Aliases: []string{"p"},
 			Subcommands: []cli.Command{
+				{
+					Name:    "duration",
+					Usage:   `Intervals between every quote in the form of a duration string (ex: "5m" or "1h30m10s")`,
+					Aliases: []string{"d", "duration"},
+					Action: func(c *cli.Context) error {
+
+						//os.Args[3] is the interval of time between quotes.
+						if len(os.Args) < 4 {
+							fmt.Println("Incorrect use of the persistent commnad," +
+								" type 'ancestorquotes persistent help' for more information")
+							return nil
+						}
+
+						duration, err := time.ParseDuration(os.Args[3])
+						if err != nil {
+							fmt.Println("Incorrect use of the persistent commnad," +
+								" type 'ancestorquotes persistent help' for more information")
+							return nil
+						}
+
+						commands.Persistent(duration)
+
+						return nil
+					},
+				},
 				{
 					Name:    "minute",
 					Usage:   "Intervals in minutes between every quote",
@@ -50,7 +77,7 @@ func main() {
 							return nil
 						}
 
-						commands.Persistent(timer, "minute")
+						commands.Persistent(time.Duration(timer) * time.Minute)
 
 						return nil
 					},
@@ -82,7 +109,7 @@ func main() {
 							return nil
 						}
 
-						commands.Persistent(timer, "second")
+						commands.Persistent(time.Duration(timer) * time.Second)
 
 						return nil
 					},


### PR DESCRIPTION
Contributes to #1. This change adds a new `duration` sub-command to the `persistent` command. The new sub-command allows the use of a duration string compatible with [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) when setting up a persistent command. 

- add `duration` sub-command to `persistent` command
- refactored `commands.Persistent` to accept a time.Duration
- updated `minute` and `seconds` sub-commands to maintain backwards compatibility