### PR TITLE
New Feature: Copying random quote onto the Clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ There will be no sleep tonight - the wild shouts and frantic drumming will see t
 
 ```
 
+#### Clip
+
+The ancestor copies a random quote onto the clipboard:
+
+```
+$ ancestorquotes clip
+The Ancestor conveyed it to your clipboard !
+
+```
+
 ### Sub-commands
 
 #### Persistent:

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	clip "github.com/atotto/clipboard"
 )
 
 // AllQuotes prints all quotes.
@@ -213,4 +215,10 @@ func Typed() {
 		}
 		time.Sleep(120 * time.Millisecond)
 	}
+}
+
+func Clip() {
+	quote := RandomQuote()
+	clip.WriteAll(quote)
+	fmt.Println("The Ancestor conveyed it to your clipboard !")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module ancestorquotes
 
 go 1.12
 
-require github.com/urfave/cli v1.22.1
+require (
+	github.com/atotto/clipboard v0.1.4
+	github.com/urfave/cli v1.22.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func main() {
 		}, {
 			Name:    "clip",
 			Usage:   "Copies a random quote onto the clipboard",
-			Aliases: []string{"c"},
+			Aliases: []string{"cp"},
 			Action: func(c *cli.Context) error {
 				commands.Clip()
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"ancestorquotes/commands"
+
 	"github.com/urfave/cli"
 )
 
@@ -153,6 +154,15 @@ func main() {
 			Aliases: []string{"typed"},
 			Action: func(c *cli.Context) error {
 				commands.Typed()
+
+				return nil
+			},
+		}, {
+			Name:    "clip",
+			Usage:   "Copies a random quote onto the clipboard",
+			Aliases: []string{"c"},
+			Action: func(c *cli.Context) error {
+				commands.Clip()
 
 				return nil
 			},


### PR DESCRIPTION
This feature copies a random ancestor quote onto the clipboard.
Can be run by using clip or cp
This feature would be helpful to users when they need to share an ancestor quote somewhere...